### PR TITLE
feat: Update default Claude model to `claude-sonnet-4-5` and simplify…

### DIFF
--- a/mcp-claude.ts
+++ b/mcp-claude.ts
@@ -262,7 +262,7 @@ class MCPClaudeFixedFinal {
         // Se não for ClaudeModel, criar um novo ClaudeModel
         this.aiModel = new ClaudeModel({
           anthropic_api_key: this.config.anthropic_api_key,
-          claude_model: this.config.claude_model || 'claude-3-5-sonnet-20241022'
+          claude_model: this.config.claude_model || 'claude-sonnet-4-5-20250929'
         });
         await this.aiModel.initialize();
       }
@@ -281,7 +281,7 @@ class MCPClaudeFixedFinal {
       // Fallback para um ClaudeModel básico
       this.aiModel = new ClaudeModel({
         anthropic_api_key: this.config.anthropic_api_key || '',
-        claude_model: 'claude-3-5-sonnet-20241022'
+        claude_model: 'claude-sonnet-4-5-20250929'
       });
     }
   }

--- a/setup.js
+++ b/setup.js
@@ -852,44 +852,15 @@ export default class ModelFactory {
       output: process.stdout,
     });
 
-    // Seleciona o provedor de IA
-    const provider = await new Promise(resolve => {
-      console.log('\n📋 Escolha o provedor de IA:');
-      console.log('  1. Claude (Anthropic)');
-      console.log('  2. GPT (OpenAI)');
-      console.log('  3. Gemini (Google)');
-      rl.question('Escolha uma opção (1-3): ', answer => {
-        switch (answer.trim()) {
-          case '2':
-            resolve('openai');
-            break;
-          case '3':
-            resolve('gemini');
-            break;
-          default:
-            resolve('claude');
-        }
-      });
-    });
-
+    // Configura Claude como provedor (único suportado atualmente)
+    const provider = 'claude';
     config.ai_provider = provider;
-    console.log(`  ✓ Provedor selecionado: ${provider}`);
 
-    // Solicita API key apropriada
-    let apiKeyPrompt, apiKeyField;
-    switch (provider) {
-      case 'openai':
-        apiKeyPrompt = '🔐 Digite sua OpenAI API key: ';
-        apiKeyField = 'openai_api_key';
-        break;
-      case 'gemini':
-        apiKeyPrompt = '🔐 Digite sua Google Gemini API key: ';
-        apiKeyField = 'gemini_api_key';
-        break;
-      default:
-        apiKeyPrompt = '🔐 Digite sua Anthropic API key: ';
-        apiKeyField = 'anthropic_api_key';
-    }
+    console.log('\n🔑 Configurando Anthropic Claude API...');
+
+    // Solicita API key do Claude
+    const apiKeyPrompt = '🔐 Digite sua Anthropic API key: ';
+    const apiKeyField = 'anthropic_api_key';
 
     // Preserva a API key existente se disponível
     if (
@@ -911,37 +882,35 @@ export default class ModelFactory {
       config[apiKeyField] = apiKey;
     }
 
-    // Seleciona o modelo específico
-    let modelOptions, modelField;
-    switch (provider) {
-      case 'openai':
-        modelOptions = ['gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo'];
-        modelField = 'openai_model';
-        break;
-      case 'gemini':
-        modelOptions = ['gemini-pro', 'gemini-pro-vision'];
-        modelField = 'gemini_model';
-        break;
-      default:
-        modelOptions = [
-          'claude-3-7-sonnet-20250219',
-          'claude-3-5-sonnet-20240620',
-          'claude-3-haiku-20240307',
-        ];
-        modelField = 'claude_model';
-    }
+    // Seleciona o modelo Claude
+    const modelOptions = [
+      { name: 'Claude Sonnet 4.5 (recomendado) ⭐', id: 'claude-sonnet-4-5-20250929' },
+      { name: 'Claude Opus 4.1', id: 'claude-opus-4-1-20250805' },
+      { name: 'Claude Opus 4', id: 'claude-opus-4-20250514' },
+      { name: 'Claude Sonnet 4', id: 'claude-sonnet-4-20250514' },
+      { name: 'Claude Sonnet 3.7', id: 'claude-3-7-sonnet-20250219' },
+      { name: 'Claude Haiku 3.5', id: 'claude-3-5-haiku-20241022' },
+      { name: 'Claude Haiku 3', id: 'claude-3-haiku-20240307' },
+    ];
+    const modelField = 'claude_model';
 
     const modelChoice = await new Promise(resolve => {
-      console.log('\n📋 Escolha o modelo específico:');
+      console.log('\n📋 Escolha o modelo Claude:');
       modelOptions.forEach((model, index) => {
-        console.log(`  ${index + 1}. ${model}`);
+        console.log(`  ${index + 1}. ${model.name}`);
       });
-      rl.question(`Escolha uma opção (1-${modelOptions.length}): `, answer => {
-        const index = parseInt(answer.trim()) - 1;
-        if (index >= 0 && index < modelOptions.length) {
-          resolve(modelOptions[index]);
+      rl.question(`Escolha uma opção (1-${modelOptions.length}) [padrão: 1]: `, answer => {
+        const trimmed = answer.trim();
+        if (trimmed === '') {
+          // Enter sem digitar = padrão (opção 1)
+          resolve(modelOptions[0].id);
         } else {
-          resolve(modelOptions[0]);
+          const index = parseInt(trimmed) - 1;
+          if (index >= 0 && index < modelOptions.length) {
+            resolve(modelOptions[index].id);
+          } else {
+            resolve(modelOptions[0].id);
+          }
         }
       });
     });

--- a/src/ai_models/claude_model.ts
+++ b/src/ai_models/claude_model.ts
@@ -53,18 +53,26 @@ export default class ClaudeModel extends BaseAIModel {
   constructor(config: ClaudeConfig) {
     super(config);
     this.client = null;
-    // Modelos que suportam tools (Claude 3+)
-    this.modelName = config.claude_model || 'claude-3-5-sonnet-20241022';
+    // Modelo padrão: Claude Sonnet 4.5 (melhor para agentes e coding)
+    this.modelName = config.claude_model || 'claude-sonnet-4-5-20250929';
 
-    // Lista de modelos que suportam tools
+    // Lista de modelos que suportam tools (todos os modelos Claude atuais)
     this.toolSupportedModels = [
-      'claude-3-5-sonnet-20241022',
+      // Claude 4.5 (latest - default)
+      'claude-sonnet-4-5-20250929',
+      // Claude 4.1 e 4
+      'claude-opus-4-1-20250805',
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+      // Claude 3.7
+      'claude-3-7-sonnet-20250219',
+      // Claude 3.5
       'claude-3-5-haiku-20241022',
+      'claude-3-5-sonnet-20241022',
+      // Claude 3
       'claude-3-opus-20240229',
       'claude-3-sonnet-20240229',
       'claude-3-haiku-20240307',
-      'claude-sonnet-4-20250514',
-      'claude-opus-4-1-20250805',
     ];
   }
 

--- a/src/configure-ai.ts
+++ b/src/configure-ai.ts
@@ -113,17 +113,23 @@ class AIConfigurator {
 
     if (provider === 'anthropic') {
       console.log('\n📚 Modelos Claude disponíveis:\n');
-      console.log('  1) Claude 3 Opus (Mais poderoso)');
-      console.log('  2) Claude 3 Sonnet (Balanceado)');
-      console.log('  3) Claude 3 Haiku (Mais rápido)');
-      console.log('  4) Claude 3.5 Sonnet (Recomendado - Melhor custo-benefício)');
+      console.log('  1) Claude Sonnet 4.5 (Recomendado) ⭐');
+      console.log('  2) Claude Opus 4.1');
+      console.log('  3) Claude Opus 4');
+      console.log('  4) Claude Sonnet 4');
+      console.log('  5) Claude Sonnet 3.7');
+      console.log('  6) Claude Haiku 3.5');
+      console.log('  7) Claude Haiku 3');
       console.log('  0) Voltar\n');
 
       models = {
-        '1': 'claude-3-opus-20240229',
-        '2': 'claude-3-sonnet-20240229',
-        '3': 'claude-3-haiku-20240307',
-        '4': 'claude-3-5-sonnet-20241022',
+        '1': 'claude-sonnet-4-5-20250929',
+        '2': 'claude-opus-4-1-20250805',
+        '3': 'claude-opus-4-20250514',
+        '4': 'claude-sonnet-4-20250514',
+        '5': 'claude-3-7-sonnet-20250219',
+        '6': 'claude-3-5-haiku-20241022',
+        '7': 'claude-3-haiku-20240307',
       };
     } else if (provider === 'openai') {
       console.log('\n📚 Modelos GPT disponíveis:\n');

--- a/src/services/backendService.ts
+++ b/src/services/backendService.ts
@@ -43,7 +43,7 @@ export interface InitializeBackendOptions {
 const DEFAULT_CONFIG: BackendConfig = {
   ai_provider: 'claude',
   anthropic_api_key: process.env.ANTHROPIC_API_KEY,
-  claude_model: 'claude-3-5-sonnet-20241022',
+  claude_model: 'claude-sonnet-4-5-20250929',
   use_native_tools: false,
   max_tokens: 4096,
   temperature: 0.7,


### PR DESCRIPTION
… setup flow

- Changed default Claude model to `claude-sonnet-4-5-20250929` across services and initialization.
- Streamlined AI provider configuration by setting Claude as the sole supported provider.
- Enhanced user experience in model selection with updated options and default fallback logic.
- Refined `toolSupportedModels` for better alignment with supported Claude models.