### PR TITLE
fix: Standardize configuration file path to `config.json`

### DIFF
--- a/src/configure-ai.ts
+++ b/src/configure-ai.ts
@@ -321,7 +321,7 @@ class AIConfigurator {
     const configPath = path.join(
       process.env.HOME || '',
       '.mcp-terminal',
-      'turso-config.json',
+      'config.json',
     );
 
     try {

--- a/src/ipcom-chat-cli.ts
+++ b/src/ipcom-chat-cli.ts
@@ -146,7 +146,7 @@ async function initTursoClient(): Promise<TursoHistoryClient> {
   const configPath = path.join(
     os.homedir(),
     '.mcp-terminal',
-    'turso-config.json',
+    'config.json',
   );
 
   if (!existsSync(configPath)) {

--- a/src/libs/dashboard-server.ts
+++ b/src/libs/dashboard-server.ts
@@ -148,7 +148,7 @@ class DashboardServer {
         const configPath = path.join(
           os.homedir(),
           '.mcp-terminal',
-          'turso-config.json',
+          'config.json',
         );
         const tursoConfig = JSON.parse(await fs.readFile(configPath, 'utf8'));
         this.tursoClient = new TursoHistoryClient(tursoConfig);

--- a/src/libs/migrate-history.ts
+++ b/src/libs/migrate-history.ts
@@ -84,7 +84,7 @@ class HistoryMigrator {
   constructor() {
     this.configDir = path.join(os.homedir(), '.mcp-terminal');
     this.historyFile = path.join(this.configDir, 'history.json');
-    this.tursoConfigFile = path.join(this.configDir, 'turso-config.json');
+    this.tursoConfigFile = path.join(this.configDir, 'config.json');
     this.migrationLogFile = path.join(this.configDir, 'migration.log');
     this.rl = readline.createInterface({
       input: process.stdin,

--- a/src/libs/turso-admin-setup.ts
+++ b/src/libs/turso-admin-setup.ts
@@ -26,7 +26,7 @@ class TursoAdminSetup {
 
   constructor() {
     this.configDir = path.join(os.homedir(), '.mcp-terminal');
-    this.configPath = path.join(this.configDir, 'turso-config.json');
+    this.configPath = path.join(this.configDir, 'config.json');
     this.adminMarkerPath = path.join(this.configDir, '.turso-admin-setup-done');
     this.client = null;
   }

--- a/src/libs/turso-client-setup.ts
+++ b/src/libs/turso-client-setup.ts
@@ -50,7 +50,7 @@ class TursoClientSetup {
 
   constructor() {
     this.configDir = path.join(os.homedir(), '.mcp-terminal');
-    this.configPath = path.join(this.configDir, 'turso-config.json');
+    this.configPath = path.join(this.configDir, 'config.json');
     this.machineIdPath = path.join(this.configDir, 'machine.json');
     this.client = null;
   }

--- a/src/libs/turso-verify-schema.ts
+++ b/src/libs/turso-verify-schema.ts
@@ -42,7 +42,7 @@ class TursoSchemaVerifier {
 
   constructor() {
     this.configDir = path.join(os.homedir(), '.mcp-terminal');
-    this.configPath = path.join(this.configDir, 'turso-config.json');
+    this.configPath = path.join(this.configDir, 'config.json');
     this.client = null;
     this.config = null;
     this.errors = [];


### PR DESCRIPTION
- Replaced all references to `turso-config.json` with `config.json` across multiple modules.
- Ensured consistent configuration file usage throughout the codebase.